### PR TITLE
rules are added to the bottom instead of the top

### DIFF
--- a/server/src/main/resources/static/js/rules-0.0.2.js
+++ b/server/src/main/resources/static/js/rules-0.0.2.js
@@ -297,7 +297,7 @@ $(document).ready(function() {
   });
 
   $("#create_new_rule").click(function (event) {
-    $('#rules_list').prepend(makeRuleDiv());
+    $('#rules_list').append(makeRuleDiv());
   });
 
   $("#cancel").click(function() {


### PR DESCRIPTION
Currently if you want to add 2 rules in this order:

rule1
rule2

in the ui, you have to do: 

rule2
rule1

with this fix, you put rules in the ui as you intend to write them
